### PR TITLE
fix: i2c slave freeze

### DIFF
--- a/firmware/common/bootloader.h
+++ b/firmware/common/bootloader.h
@@ -5,6 +5,20 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// Comment out for the SO8N target: PA13 is SWDIO there, and on Nucleo
+// ENTER_BL moves to PB0 (bonded to I2C2_SCL/OLED on the SO8N target).
+// #define NUCLEO_DEBUG
+
+#ifdef NUCLEO_DEBUG
+#define ENTER_BL_PORT        GPIOB
+#define ENTER_BL_PIN         0
+#define ENTER_BL_RCC_ENABLE  RCC_IOPENR_GPIOBEN
+#else
+#define ENTER_BL_PORT        GPIOA
+#define ENTER_BL_PIN         13
+#define ENTER_BL_RCC_ENABLE  RCC_IOPENR_GPIOAEN
+#endif
+
 #define TOMBSTONE_SIZE              (0x20)
 
 #define PRELOADER_BASE              (FLASH_BASE)

--- a/firmware/preloader/include/gpio.h
+++ b/firmware/preloader/include/gpio.h
@@ -1,8 +1,6 @@
 #ifndef _GPIO_H
 #define _GPIO_H
 
-#define PIN_13          (13)
-
 typedef enum {
     GPIO_MODE_INPUT     = 0x0,
     GPIO_MODE_OUTPUT    = 0x1,

--- a/firmware/preloader/src/main.c
+++ b/firmware/preloader/src/main.c
@@ -57,25 +57,25 @@ int main(void) {
 
     handleSystemBootLoader();
 
-    // Enable GPIOA
-    RCC->IOPENR |= RCC_IOPENR_GPIOAEN;
+    // Enable ENTER_BL's GPIO port (see common/bootloader.h)
+    RCC->IOPENR |= ENTER_BL_RCC_ENABLE;
 
     // Enable CRC clock
     RCC->AHBENR |= RCC_AHBENR_CRCEN;
-    
 
-    // Configure PA13 as Input, Pull-up
-    gpioConfig(GPIOA, PIN_13,
+
+    // Configure ENTER_BL as Input, Pull-up
+    gpioConfig(ENTER_BL_PORT, ENTER_BL_PIN,
                     GPIO_MODE_INPUT,
                     GPIO_OTYPE_PP,     // doesn’t matter for input
                     GPIO_SPEED_LOW,    // doesn’t matter for input
                     GPIO_PULLUP);
 
 
-    // 2 second wait, debounced 
-    if (!(GPIOA->IDR & (1 << PIN_13))) {
+    // 2 second wait, debounced
+    if (!(ENTER_BL_PORT->IDR & (1 << ENTER_BL_PIN))) {
         delayMs(DEBOUNCE_DELAY);
-        if (!(GPIOA->IDR & (1 << PIN_13))) {  // check again
+        if (!(ENTER_BL_PORT->IDR & (1 << ENTER_BL_PIN))) {  // check again
             // button pressed -> system bootloader
             resetToSystemBootLoader();
         }

--- a/firmware/userapp/Core/Inc/main.h
+++ b/firmware/userapp/Core/Inc/main.h
@@ -28,6 +28,7 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32g0xx_hal.h"
+#include "bootloader.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -60,8 +61,9 @@ void Error_Handler(void);
 /* USER CODE END EFP */
 
 /* Private defines -----------------------------------------------------------*/
-#define ENTER_BL_Pin GPIO_PIN_13
-#define ENTER_BL_GPIO_Port GPIOA
+// NUCLEO_DEBUG / ENTER_BL_PORT / ENTER_BL_PIN: see common/bootloader.h
+#define ENTER_BL_Pin ((uint16_t)(1 << ENTER_BL_PIN))
+#define ENTER_BL_GPIO_Port ENTER_BL_PORT
 
 /* USER CODE BEGIN Private defines */
 

--- a/firmware/userapp/Core/Inc/slave.h
+++ b/firmware/userapp/Core/Inc/slave.h
@@ -19,6 +19,7 @@ extern "C" {
 #define BOOTLOADER_TRIGGER_MAGIC      0xB007B007UL
 
 void Slave_Init(void);
+void Slave_Poll(void);
 
 uint8_t Slave_RegRead(uint8_t addr);
 void Slave_RegWrite(uint8_t addr, uint8_t val);

--- a/firmware/userapp/Core/Src/display.c
+++ b/firmware/userapp/Core/Src/display.c
@@ -12,6 +12,8 @@ static u8g2_t myDisplay;
 
 static char lcd_buf[20] = {0};
 
+static void drawCenteredStr(int16_t y, const char *str);
+
 uint8_t u8x8_gpio_and_delay(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {
     switch(msg)
@@ -62,8 +64,7 @@ void Display_ScrollText(const char *text) {
     int text_w = u8g2_GetStrWidth(&myDisplay, text);
     int y = lower_y + lower_h - 2; /* baseline near bottom */
 
-    /* Start just off the right edge and scroll left until just off the left edge */
-    for (int x = screen_w; x > -text_w; x--) {
+    for (int x = 0; x > screen_w - text_w; x--) {
         /* Clear only the lower third by drawing a background box (draw color 0) */
         u8g2_SetDrawColor(&myDisplay, 0);
         u8g2_DrawBox(&myDisplay, 0, lower_y, screen_w, lower_h);
@@ -130,8 +131,12 @@ void Display_Init(void)
     u8g2_SendBuffer(&myDisplay);
     Display_ScrollText("xboxresearch.com");
 
-    // Cleanup
     u8g2_ClearDisplay(&myDisplay);
+    u8g2_SetFont(&myDisplay, u8g2_font_5x7_mr);
+    drawCenteredStr(9, "Waiting");
+    drawCenteredStr(19, "for");
+    drawCenteredStr(29, "POST codes");
+    u8g2_SendBuffer(&myDisplay);
 }
 
 static void drawCenteredStr(int16_t y, const char *str) {

--- a/firmware/userapp/Core/Src/main.c
+++ b/firmware/userapp/Core/Src/main.c
@@ -118,6 +118,7 @@ int main(void)
   while (1)
   {
     Display_Tick();
+    Slave_Poll();
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */

--- a/firmware/userapp/Core/Src/slave.c
+++ b/firmware/userapp/Core/Src/slave.c
@@ -1,17 +1,23 @@
 #include "slave.h"
 #include "bootloader.h"
+#include "postcodes.h"
 
 extern I2C_HandleTypeDef hi2c1;
 
 static uint8_t register_map[REG_MAP_SIZE] = {0}; // Register map storage
 static uint8_t new_segment_available = 0;
-static uint8_t reg_index = 0;              // Current write address
+static uint8_t reg_index = 0;
 
 static uint32_t error = HAL_OK;
 static uint8_t error_state = 0;
 
 static uint8_t bootloader_magic_buf[4] = {0};
 static uint8_t receiving_boot_magic = 0;   // Set while a BOOTLOADER_TRIGGER_I2C_ADDR write is in flight
+
+static uint8_t rx_scratch[REG_MAP_SIZE + 1]; // [0]=target register, [1..]=data
+
+// Set by ISR callbacks, checked by Slave_Poll() from the main loop.
+static volatile uint8_t need_restart = 0;
 
 void Slave_Start(void);
 
@@ -22,6 +28,14 @@ void Slave_Start(void);
 void Slave_Init(void)
 {
         Slave_Start();
+}
+
+void Slave_Poll(void)
+{
+        if (need_restart) {
+                need_restart = 0;
+                Slave_Start();
+        }
 }
 
 void Slave_Start(void)
@@ -35,7 +49,6 @@ void Slave_Start(void)
 
         HAL_I2C_EnableListen_IT(&hi2c1);
 }
-
 
 void HAL_I2C_AddrCallback(I2C_HandleTypeDef *hi2c, uint8_t TransferDirection, uint16_t AddrMatchCode)
 {
@@ -55,11 +68,12 @@ void HAL_I2C_AddrCallback(I2C_HandleTypeDef *hi2c, uint8_t TransferDirection, ui
                         receiving_boot_magic = 1;
                         ret = HAL_I2C_Slave_Seq_Receive_IT(&hi2c1, bootloader_magic_buf, sizeof(bootloader_magic_buf), I2C_LAST_FRAME);
                 } else {
-                        ret = HAL_I2C_Slave_Seq_Receive_IT(&hi2c1, &reg_index, 1, I2C_NEXT_FRAME);
+                        // Single call for the whole transaction
+                        ret = HAL_I2C_Slave_Seq_Receive_IT(&hi2c1, rx_scratch, sizeof(rx_scratch), I2C_NEXT_FRAME);
                 }
 
                 if (ret != HAL_OK) {
-                        Error_Handler();
+                        need_restart = 1;
                 }
         }
 }
@@ -70,7 +84,29 @@ void HAL_I2C_ListenCpltCallback(I2C_HandleTypeDef *hi2c)
                 return;
         }
 
-        Slave_Start();
+        need_restart = 1;
+}
+
+static void Slave_FlushRxScratch(void)
+{
+        if (hi2c1.pBuffPtr >= rx_scratch && hi2c1.pBuffPtr <= rx_scratch + sizeof(rx_scratch)) {
+                uint16_t received = (uint16_t)(hi2c1.pBuffPtr - rx_scratch);
+
+                if (received >= 1) {
+                        uint8_t start_addr = rx_scratch[0];
+                        uint16_t data_len = received - 1;
+
+                        for (uint16_t i = 0; i < data_len; i++) {
+                                register_map[(start_addr + i) % REG_MAP_SIZE] = rx_scratch[1 + i];
+                        }
+                        reg_index = (uint8_t)(start_addr + data_len);
+
+                        // Did the received range contain Segment register?
+                        if (start_addr <= REG_Segments && REG_Segments < start_addr + data_len) {
+                                new_segment_available = 1;
+                        }
+                }
+        }
 }
 
 void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c)
@@ -93,9 +129,7 @@ void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c)
                 return;
         }
 
-        if (HAL_I2C_Slave_Seq_Receive_IT(hi2c, &register_map[reg_index++], 1, I2C_NEXT_FRAME) != HAL_OK) {
-                Error_Handler();
-        }
+        Slave_FlushRxScratch();
 }
 
 void HAL_I2C_AbortCpltCallback(I2C_HandleTypeDef *hi2c)
@@ -104,15 +138,8 @@ void HAL_I2C_AbortCpltCallback(I2C_HandleTypeDef *hi2c)
                 return;
         }
 
-        Error_Handler();
+        need_restart = 1;
 }
-
-void Slave_HandleComplete()
-{
-        if (reg_index == 0x26 /*&& (register_map[0x24] & 0x0F) > 0*/)
-                new_segment_available = 1;
-}
-
 
 void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
 {
@@ -122,31 +149,31 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
 
         error = HAL_I2C_GetError(&hi2c1);
 
-        switch (error) {
-                case HAL_I2C_ERROR_AF:
-                        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
-                        break;
-                case HAL_I2C_ERROR_BERR:
-                        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_BERR);
-                        error_state = 1;
-                        break;
-                default:
-                        Error_Handler();
+        // error is a bitmask
+        if (error & HAL_I2C_ERROR_AF) {
+            __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
         }
-                        
+        if (error & HAL_I2C_ERROR_ARLO) {
+            __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ARLO);
+        }
+        if (error & HAL_I2C_ERROR_OVR) {
+            __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_OVR);
+        }
+        if (error & HAL_I2C_ERROR_BERR) {
+            __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_BERR);
+            error_state = 1;
+        }
+
         hi2c->ErrorCode = 0;
 
         if (receiving_boot_magic) {
-                // Truncated bootloader-trigger write; discard it rather than
-                // let stale reg_index state be mistaken for a completed
-                // register-map transfer below.
+                // Truncated bootloader-trigger write; discard it.
                 receiving_boot_magic = 0;
         } else {
-                Slave_HandleComplete();
+                Slave_FlushRxScratch();
         }
 
-        Slave_Start();
-
+        need_restart = 1;
 }
 
 uint8_t Slave_RegRead(uint8_t addr) { return register_map[addr % REG_MAP_SIZE]; }


### PR DESCRIPTION
Finally the POST code display seems stable

- [fix: I2C stalling/crashing due to long running interrupt handling, better buffer handling](https://github.com/xboxoneresearch/ASPECT2-PCB/commit/f2a1ae58fc5c5c96b9dd4f01f87e7e223d6e5f53) 
- [feat(display): Quicker splashscreen, show 'Waiting for POST codes' initially](https://github.com/xboxoneresearch/ASPECT2-PCB/commit/71ce74f25d6205254fd59dd3e37dbb7885fe4f15)
- [feat/meta: Allow quickly changing the fw build from running on ASPECT2-PCB to Nucleo devboard](https://github.com/xboxoneresearch/ASPECT2-PCB/commit/8370c6d0fe3de4a2d04ce815645cff4a691efaec)